### PR TITLE
[#3] Fix: gateway에서 FeignClient를 사용하기 위해 의존성 추가

### DIFF
--- a/com.spring.dozen.gateway/build.gradle
+++ b/com.spring.dozen.gateway/build.gradle
@@ -1,51 +1,55 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.3.6'
-	id 'io.spring.dependency-management' version '1.1.6'
+    id 'java'
+    id 'org.springframework.boot' version '3.3.6'
+    id 'io.spring.dependency-management' version '1.1.6'
 }
 
 group = 'com.spring.dozen'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(17)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('springCloudVersion', "2023.0.4")
+    set('springCloudVersion', "2023.0.4")
 }
 
 dependencies {
-	implementation 'io.jsonwebtoken:jjwt:0.12.6'
-	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-	implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
-	implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
-	implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'io.projectreactor:reactor-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'io.jsonwebtoken:jjwt:0.12.6'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'org.springframework.cloud:spring-cloud-starter-gateway'
+    implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    compileOnly 'io.jsonwebtoken:jjwt-api'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson'
 }
 
 dependencyManagement {
-	imports {
-		mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
-	}
+    imports {
+        mavenBom "org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}"
+    }
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/com.spring.dozen.gateway/src/main/java/com/spring/dozen/gateway/LocalJwtAuthenticationFilter.java
+++ b/com.spring.dozen.gateway/src/main/java/com/spring/dozen/gateway/LocalJwtAuthenticationFilter.java
@@ -8,9 +8,9 @@ import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Component;
 import org.springframework.web.server.ServerWebExchange;
@@ -35,7 +35,8 @@ public class LocalJwtAuthenticationFilter implements GlobalFilter {
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
         String path = exchange.getRequest().getURI().getPath();
-        if (path.startsWith("/api/auth")) {
+        // hub-manager 회원가입은 토큰 검증이 필요하므로 제외
+        if (path.startsWith("/api/auth") && !path.equals("/api/auth/sign-up/hub-manager")) {
             return chain.filter(exchange);
         }
 


### PR DESCRIPTION
## **🔗 Related Issues**
> 예) 관련이슈 #번호


## **📋 Description**
> 이 PR에서 해결한 문제 또는 추가된 기능을 간략히 설명
- `gateway`가 `reactive`, 비동기 방식이기 때문에 `FeignClien`t를 사용하면 충돌이 생겨 외부 서비스 호출이 안됩니다.
- `FeignClient`는 동기 방식을 사용하기 때문에 `spring-web` 의존성을 추가하여 동기적으로 호출할 수 있도록 조치했습니다.
- 허브관리자의 회원가입의 경우는 인증 및 마스터권한의 토큰이 있어야 하므로 LocalJwtAuthenticationFilter를 타도록 수정했습니다.

## **👀 Review Points**
> 리뷰어가 특별히 봐주었으면 하는 부분